### PR TITLE
Ensure unique_id only return strings

### DIFF
--- a/custom_components/min_renovasjon/sensor.py
+++ b/custom_components/min_renovasjon/sensor.py
@@ -38,7 +38,8 @@ class MinRenovasjonSensor(Entity):
     @property
     def unique_id(self):
         """Return a unique ID to use for this entity."""
-        return self._min_renovasjon.get_calender_for_fraction(self._fraction_id)
+        fraction = self._min_renovasjon.get_calender_for_fraction(self._fraction_id)
+        return f"{fraction[0]}-{fraction[1]}" if fraction is not None else ""
     
     @property
     def name(self):


### PR DESCRIPTION
Home assistant doesn't seem to like it when unique_id returns anything other than strings